### PR TITLE
Feature: GM generated login credential

### DIFF
--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -32,7 +32,7 @@ fi
 touch /var/log/httpd/access_log && tail -f /var/log/httpd/access_log &
 touch /var/log/httpd/error_log && tail -f /var/log/httpd/error_log &
 touch /var/log/sync_repo.log && chown $HTTPD_USER /var/log/sync_repo.log && tail -f /var/log/sync_repo.log &
-touch /var/log/wsgi.log && chown $HTTPD_USER /var/log/wsgi.log && tail -f /var/log/wsgi.log &
+mkdir /var/log/wsgi/ && touch /var/log/wsgi/wsgi.log && chown -R $HTTPD_USER /var/log/wsgi/ && tail -f /var/log/wsgi/wsgi.log &
 
 # Set the apache user's crontab 
 # TODO it would be preferable to fully configure this via the Dockerfile

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,14 +1,13 @@
-from fastapi import FastAPI, BackgroundTasks, HTTPException
+from fastapi import FastAPI, BackgroundTasks, HTTPException, Request
 from os import environ
 from models import models
 from db import db
-from util.httpd_utils import add_httpd_user
+from util.httpd_utils import add_httpd_user, RequestScopeInfo
 from util.wsgi_error_logging import with_error_logging
 from secrets import token_urlsafe
 
 import logging
 import requests
-from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 logger = logging.getLogger("default")
@@ -23,11 +22,12 @@ def get_public():
     return {"message": "This is a public route!" }
 
 @app.get('/private/verify-auth')
-def verify_auth():
+def verify_auth(request: Request):
     """ Sanity check basic-auth gated endpoint. Used by clients to confirm that
     handshake protocol succeeded. Auth is handled at the httpd layer.
     """
-    return { "auth-status": "success" }
+    scope_info = RequestScopeInfo(request)
+    return { "whoami": scope_info.user }
 
 @with_error_logging
 def follow_up_challenge(request: models.ChallengeInitiateRequest, challenge: models.ChallengeInitiateResponse):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,10 +4,12 @@ from models import models
 from db import db
 from util.httpd_utils import add_httpd_user
 from util.wsgi_error_logging import with_error_logging
+from secrets import token_urlsafe
 
 import logging
 import requests
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 
 logger = logging.getLogger("default")
 
@@ -29,12 +31,20 @@ def get_private():
 def follow_up_challenge(request: models.ChallengeInitiateRequest, challenge: models.ChallengeInitiateResponse):
     """ Background task that follows up on a challenge initiated by a client. """
     logger.info(f"C/R: Sending callback to {request.callback_address}")
-    resp = requests.post(request.callback_address, data=models.ChallengeCompleteRequest(id_secret=challenge.id_secret).model_dump_json())
+    credentials = models.ChallengeCompleteRequest(
+        id_secret=challenge.id_secret,
+        capability=token_urlsafe(24),
+        expires=datetime.now() + timedelta(hours=2))
+
+    resp = requests.post(request.callback_address, data=credentials.model_dump_json())
     completed_challenge = models.ChallengeCompleteResponse.model_validate(resp.json())
     if completed_challenge.challenge_secret == challenge.challenge_secret:
         logger.info(f"C/R: Callback response contains correct challenge secret")
-        add_httpd_user(request.client_name, completed_challenge.capability)
-        db.complete_challenge_session(request.client_name, completed_challenge.challenge_secret)
+        add_httpd_user(request.client_name, credentials.capability)
+        # TODO There's a big opportunity for data desync if the server crashes between 
+        # updating the htpassword file and updating the database
+        db.complete_challenge_session(
+            request.client_name, completed_challenge.challenge_secret, credentials)
     else:
         logger.error(f"C/R: Callback response contains incorrect challenge secret. Ignoring")
 

--- a/webapp/client_app.py
+++ b/webapp/client_app.py
@@ -52,7 +52,7 @@ async def post_initiate_challenge(request: models.ChallengeCompleteRequest, back
     print(f"C/R: Callback initiated by {request.id_secret}")
     if request.id_secret != STATE_DICT['id_secret']:
         raise HTTPException(403, "Unexpected ID token")
-    print(f"C/R: id secret matches, replying with capability")
+    print(f"C/R: id secret matches, replying with challenge secret")
     background_tasks.add_task(test_auth, request.capability)
     return models.ChallengeCompleteResponse(challenge_secret=STATE_DICT['challenge_secret'])
 
@@ -62,4 +62,4 @@ def test_auth(capability: str):
     auth_addr = f"{GM_ADDRESS}/api/private/verify-auth"
     print(f"C/R: Sending an authenticated request to the Object Server at {auth_addr}")
     resp = requests.get(auth_addr, auth=HTTPBasicAuth(CLIENT_NAME, capability))
-    print(resp.status_code)
+    print(f"C/R: Authenticated to Object Server as {resp.json()['whoami']}", flush=True)

--- a/webapp/client_app.py
+++ b/webapp/client_app.py
@@ -59,7 +59,7 @@ async def post_initiate_challenge(request: models.ChallengeCompleteRequest, back
 def test_auth(capability: str):
     """ Step 3: Submit an authenticated request to the object server. """
     time.sleep(1)
-    auth_addr = f"{GM_ADDRESS}/api/private"
+    auth_addr = f"{GM_ADDRESS}/api/private/verify-auth"
     print(f"C/R: Sending an authenticated request to the Object Server at {auth_addr}")
     resp = requests.get(auth_addr, auth=HTTPBasicAuth(CLIENT_NAME, capability))
     print(resp.status_code)

--- a/webapp/client_app.py
+++ b/webapp/client_app.py
@@ -52,10 +52,9 @@ async def post_initiate_challenge(request: models.ChallengeCompleteRequest, back
     print(f"C/R: Callback initiated by {request.id_secret}")
     if request.id_secret != STATE_DICT['id_secret']:
         raise HTTPException(403, "Unexpected ID token")
-    capability = token_urlsafe(16)
     print(f"C/R: id secret matches, replying with capability")
-    background_tasks.add_task(test_auth, capability)
-    return models.ChallengeCompleteResponse(challenge_secret=STATE_DICT['challenge_secret'], capability=capability)
+    background_tasks.add_task(test_auth, request.capability)
+    return models.ChallengeCompleteResponse(challenge_secret=STATE_DICT['challenge_secret'])
 
 def test_auth(capability: str):
     """ Step 3: Submit an authenticated request to the object server. """

--- a/webapp/db/db.py
+++ b/webapp/db/db.py
@@ -37,14 +37,14 @@ def create_auth_session(client_name: str) -> models.ChallengeInitiateResponse:
 def _get_pending_auth_session(session: Session, client_name: str, challenge_secret: str) -> DbClientAuthSession:
     client = session.scalar(select(DbClient).where(DbClient.name == client_name).where(DbClient.valid == True))
     if client is None:
-        raise HTTPException(404, "Given client name is invalid")
+        raise HTTPException(401, "Given client name is invalid")
 
     auth_session : DbClientAuthSession = session.scalar(select(DbClientAuthSession)
         .where(DbClientAuthSession.client_id == client.id)
         .where(DbClientAuthSession.challenge_secret == challenge_secret)
         .where(DbClientAuthSession.auth_state == DbAuthState.PENDING))
     if auth_session is None:
-        raise HTTPException(404, "No valid challenge/response session in progress")
+        raise HTTPException(401, "No valid challenge/response session in progress")
     return auth_session
 
 def activate_auth_session(client_name: str, challenge_secret: str, expires: datetime):

--- a/webapp/db/db.py
+++ b/webapp/db/db.py
@@ -1,11 +1,12 @@
 from sqlalchemy import create_engine, select
-from sqlalchemy.orm import sessionmaker
-from .db_schema import Base, DbClient, DbClientChallengeSession
+from sqlalchemy.orm import sessionmaker, Session
+from .db_schema import Base, DbClient, DbClientAuthSession, DbAuthState
 from os import environ
 from models import models
 from fastapi import HTTPException
 from secrets import token_urlsafe
 import logging
+from datetime import datetime
 
 logger = logging.getLogger("default")
 
@@ -16,14 +17,14 @@ Base.metadata.create_all(engine)
 DbSession = sessionmaker(bind=engine)
 
 
-def create_challenge_session(client_name: str) -> models.ChallengeInitiateResponse:
+def create_auth_session(client_name: str) -> models.ChallengeInitiateResponse:
     """ Create a new challenge session in the database """
     with DbSession() as session:
         client = session.scalar(select(DbClient).where(DbClient.name == client_name).where(DbClient.valid == True))
         if client is None:
             raise HTTPException(404, "Given client name is invalid")
         
-        client_challenge = DbClientChallengeSession(client.id, token_urlsafe(16), token_urlsafe(16))
+        client_challenge = DbClientAuthSession(client.id, token_urlsafe(16), token_urlsafe(16))
 
         session.add(client_challenge)
 
@@ -32,19 +33,38 @@ def create_challenge_session(client_name: str) -> models.ChallengeInitiateRespon
         return models.ChallengeInitiateResponse(
             id_secret=client_challenge.id_secret, challenge_secret=client_challenge.challenge_secret)
         
-def complete_challenge_session(client_name: str, challenge_secret: str):
-    """ Resolve a challenge session in the database """
+
+def _get_pending_auth_session(session: Session, client_name: str, challenge_secret: str) -> DbClientAuthSession:
+    client = session.scalar(select(DbClient).where(DbClient.name == client_name).where(DbClient.valid == True))
+    if client is None:
+        raise HTTPException(404, "Given client name is invalid")
+
+    auth_session : DbClientAuthSession = session.scalar(select(DbClientAuthSession)
+        .where(DbClientAuthSession.client_id == client.id)
+        .where(DbClientAuthSession.challenge_secret == challenge_secret)
+        .where(DbClientAuthSession.auth_state == DbAuthState.PENDING))
+    if auth_session is None:
+        raise HTTPException(404, "No valid challenge/response session in progress")
+    return auth_session
+
+def activate_auth_session(client_name: str, challenge_secret: str, expires: datetime):
+    """ Activate an auth session in the database after the handshake protocol succeeds """
     with DbSession() as session:
-        client = session.scalar(select(DbClient).where(DbClient.name == client_name).where(DbClient.valid == True))
-        if client is None:
-            raise HTTPException(404, "Given client name is invalid")
+        auth_session = _get_pending_auth_session(session, client_name, challenge_secret)
+        auth_session.activate(expires)
+        session.add(auth_session)
+        session.commit()
 
-        active_challenge = session.scalar(select(DbClientChallengeSession)
-            .where(DbClientChallengeSession.client_id == client.id)
-            .where(DbClientChallengeSession.challenge_secret == challenge_secret))
-        if active_challenge is None:
-            raise HTTPException(404, "No valid challenge/response session in progress")
+        return True # TODO what other information do we need here?
 
-        session.delete(active_challenge)
+def fail_auth_session(client_name: str, challenge_secret: str):
+    """ Fail an auth session in the database after the handshake protocol fails 
+    # TODO clear these out on a regular basis
+    """
+    with DbSession() as session:
+        auth_session = _get_pending_auth_session(session, client_name, challenge_secret)
+        auth_session.fail()
+        session.add(auth_session)
+        session.commit()
 
         return True # TODO what other information do we need here?

--- a/webapp/db/db_schema.py
+++ b/webapp/db/db_schema.py
@@ -1,6 +1,8 @@
 from sqlalchemy import Column, String, Boolean, Integer, Float, DateTime, ForeignKey
 from sqlalchemy.orm import DeclarativeBase, Mapped, relationship, mapped_column
 from uuid import uuid4
+from datetime import datetime
+from enum import Enum
 
 def _gen_uuid():
     return str(uuid4())
@@ -16,23 +18,46 @@ class DbClient(Base):
     name = Column(String, unique=True, nullable=False)
     valid = Column(Boolean, default=True)
 
-    challenge_sessions: Mapped[list["DbClientChallengeSession"]] = relationship(cascade="delete")
+    auth_sessions: Mapped[list["DbClientAuthSession"]] = relationship(cascade="delete")
 
     def __init__(self, name):
         self.name = name
         self.valid = True
 
-class DbClientChallengeSession(Base):
+class DbAuthState(str, Enum):
+    PENDING = 'PENDING'
+    ACTIVE = 'ACTIVE'
+    FAILED = 'FAILED'
+
+class DbClientAuthSession(Base):
     """ Table for tracking in-progress challenge/response sessions with a client """
-    __tablename__ = "client_challenge_sessions"
+    __tablename__ = "client_auth_sessions"
     id = Column(String, primary_key=True, default = _gen_uuid)
     client_id: Mapped[String] = mapped_column(ForeignKey('client.id'))
+    auth_state = Column(String, nullable=False)
 
-    id_secret = Column(String, unique=True, nullable=False)
-    challenge_secret = Column(String, unique=True, nullable=False)
+    id_secret = Column(String, unique=True)
+    challenge_secret = Column(String, unique=True)
+
+    initiated = Column(DateTime, default=datetime.now())
+    expires   = Column(DateTime, default=datetime.now())
 
     def __init__(self, client_id, id_secret, challenge_secret):
         self.id = _gen_uuid()
         self.client_id = client_id
         self.id_secret = id_secret
+        self.auth_state = DbAuthState.PENDING
         self.challenge_secret = challenge_secret
+        self.initiated = datetime.now()
+
+    def activate(self, expires):
+        self.auth_state = DbAuthState.ACTIVE
+        self.expires = expires
+        self.challenge_secret = None
+        self.id_secret = None
+    
+    def fail(self):
+        self.auth_state = DbAuthState.FAILED
+        self.challenge_secret = None
+        self.id_secret = None
+

--- a/webapp/models/models.py
+++ b/webapp/models/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+from datetime import datetime
 
 
 
@@ -14,7 +15,8 @@ class ChallengeInitiateResponse(BaseModel):
 
 class ChallengeCompleteRequest(BaseModel):
     id_secret: str = Field(description="Identifier token that the server presents to the callback_address")
+    capability: str = Field(description="The capability negotiated between the client and the server")
+    expires: datetime = Field(description="The expiry time of the negotiated capability")
 
 class ChallengeCompleteResponse(BaseModel):
     challenge_secret: str = Field(description="Challenge Secret that the client returns to the server")
-    capability: str = Field(description="The capability negotiated between the client and the server")

--- a/webapp/util/httpd_utils.py
+++ b/webapp/util/httpd_utils.py
@@ -1,5 +1,9 @@
 from subprocess import Popen, PIPE
 from os import environ
+from fastapi import Request
+
+import logging
+logger = logging.getLogger("default")
 
 HTTPD_PASSWD_FILE = f"{environ['DATA_DIR']}/.htpasswd"
 
@@ -10,3 +14,10 @@ def add_httpd_user(username:str, password:str):
 
     if httpd_call.returncode:
         raise RuntimeError(f"htpasswd returned nonzero exit code: {httpd_call.returncode}: {err}")
+
+class RequestScopeInfo:
+    environ: dict
+    user: str
+    def __init__(self, request: Request):
+        self.environ = request.scope.get('wsgi_environ', {})
+        self.user = self.environ.get('REMOTE_USER', None)

--- a/webapp/wsgi.py
+++ b/webapp/wsgi.py
@@ -1,9 +1,8 @@
 import os
 from logging.config import dictConfig
-from app import app
 from a2wsgi import ASGIMiddleware
 
-logdir = "/var/log/"
+logdir = "/var/log/wsgi/"
 dictConfig({
     "version": 1,
     "formatters": {
@@ -23,6 +22,7 @@ dictConfig({
     },
     "root": {"level": "DEBUG", "handlers": ["file"]}
 })
+from app import app
 
 
 application = ASGIMiddleware(app)


### PR DESCRIPTION
- Update the handshake protocol to generate the final credential on the GM side rather than the client side
- Update the challenge sessions table to track the start and end of session lifetimes
    - Still TODO: Clean up this table at a regular interval via a cron job
- Add a sanity check auth-gated endpoint that clients can use to confirm whether their handshake suceeded 