### PR TITLE
Feature/access tracking data model

### DIFF
--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -27,6 +27,11 @@ touch $DATA_DIR/.htpasswd && chown apache:apache $DATA_DIR/.htpasswd
 
 # start fastapi
 su -l $HTTPD_USER -s /bin/bash -c "cd /srv/app; nohup uvicorn app:app --host 0.0.0.0 --port 8089" &
+UVICORN_PID=$!
 
 # Start httpd
-httpd -D FOREGROUND
+httpd -D FOREGROUND &
+HTTPD_PID=$!
+
+# exit if either uvicorn or httpd dies
+wait -n $UVICORN_PID $HTTPD_PID

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ volumes:
   gmfs-data-vol:
   gmfs-git-vol:
 services:
+  # Main Services
   gm-file-server-init:
     image: glidein-manager-file-server
     build: .
@@ -30,6 +31,7 @@ services:
     ports:
       - "8080:80"
 
+  # Test Containers
   sample-client:
     image: glidein-manager-file-server
     build: .
@@ -43,3 +45,16 @@ services:
     working_dir: /srv/app
     entrypoint: ['uvicorn', 'test.test_client:app', '--host', '0.0.0.0', '--port', '8089']
 
+  db-profile:
+    profiles: ["db-test"]
+    image: glidein-manager-file-server
+    build: .
+    environment:
+      - API_PREFIX=/api
+      - GM_ADDRESS=http://gm-file-server
+      - CALLBACK_ADDRESS=http://sample-client:8089/public/challenge/response
+      - CLIENT_NAME=sample-client
+    working_dir: /srv/app
+    entrypoint: ['python3', '-m', 'test.benchmark_db']
+    volumes:
+      - gmfs-data-vol:/etc/gm-file-server/data

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -8,7 +8,7 @@ from sys import stdout
 from util.httpd_utils import add_httpd_user
 from secrets import token_urlsafe
 from scheduler import init_scheduler
-from typing import Optional
+from typing import Optional, Literal
 
 from contextlib import asynccontextmanager
 
@@ -44,7 +44,7 @@ def get_repo_status() -> models.RepoListing:
 @app.get('/public/client-status')
 def get_client_statuses(
         report_time: Optional[datetime] = None, 
-        auth_state: Optional[db.DbAuthState] = None, 
+        auth_state: Optional[models.AuthStateQuery] = models.AuthStateQuery.ANY,
         latest_commit: Optional[bool] = None) -> list[models.ClientStatus]:
     """ Get the list of active clients to the server, and the sync status of their git repos """
     return db.get_client_status_report(report_time, auth_state, latest_commit)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -43,7 +43,7 @@ def get_repo_status() -> models.RepoListing:
 @app.get('/public/client-status')
 def get_client_statuses() -> list[models.ClientStatus]:
     """ Get the list of active clients to the server, and the sync status of their git repos """
-    return db.get_all_client_statuses()
+    return db.get_current_client_statuses()
 
 @app.get('/private/verify-auth')
 def verify_auth(credentials: Annotated[HTTPBasicCredentials, Depends(security)]):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -8,6 +8,7 @@ from sys import stdout
 from util.httpd_utils import add_httpd_user
 from secrets import token_urlsafe
 from scheduler import init_scheduler
+from typing import Optional
 
 from contextlib import asynccontextmanager
 
@@ -37,13 +38,16 @@ def get_public():
 
 @app.get('/public/repo-status')
 def get_repo_status() -> models.RepoListing:
-    """ Return the name of the git repo """
+    """ Return the name and latest commit of the git repo """
     return git_utils.get_repo_status()
 
 @app.get('/public/client-status')
-def get_client_statuses() -> list[models.ClientStatus]:
+def get_client_statuses(
+        report_time: Optional[datetime] = None, 
+        auth_state: Optional[db.DbAuthState] = None, 
+        latest_commit: Optional[bool] = None) -> list[models.ClientStatus]:
     """ Get the list of active clients to the server, and the sync status of their git repos """
-    return db.get_current_client_statuses()
+    return db.get_client_status_report(report_time, auth_state, latest_commit)
 
 @app.get('/private/verify-auth')
 def verify_auth(credentials: Annotated[HTTPBasicCredentials, Depends(security)]):

--- a/webapp/db/client_state_report.py
+++ b/webapp/db/client_state_report.py
@@ -1,0 +1,57 @@
+from sqlalchemy import select, text
+from db.db_schema import DbClient, DbGitCommit, DbClientCommitAccess, DbClientAuthEvent, DbAuthState, DbClientStateView
+from sqlalchemy.orm import Session
+from datetime import datetime, timedelta
+from functools import wraps
+
+# SQL literal for generating a report on 
+REPORT_SQL = """
+WITH latest_auth AS (
+    SELECT client_auth_sessions.* FROM client
+    LEFT JOIN client_auth_sessions ON client.id = client_auth_sessions.client_id
+    WHERE client_auth_sessions.id = (
+        SELECT id FROM client_auth_sessions
+        WHERE client_auth_sessions.client_id = client.id
+        AND initiated <= :report_time
+        ORDER BY initiated DESC
+        LIMIT 1
+    )
+), latest_commit AS (
+    SELECT client_commit_access.* FROM client
+    LEFT JOIN client_commit_access ON client.id = client_commit_access.client_id
+    WHERE client_commit_access.id = (
+        SELECT id FROM client_commit_access
+        WHERE client_commit_access.client_id = client.id
+        AND access_time <= :report_time
+        ORDER BY access_time DESC
+        LIMIT 1
+    )
+)
+SELECT 
+    client.id, client.name,
+    latest_auth.auth_state, latest_auth.initiated, latest_auth.expires,
+    latest_commit.commit_hash, latest_commit.access_time
+FROM client
+LEFT JOIN latest_auth ON latest_auth.client_id = client.id
+LEFT JOIN latest_commit ON latest_commit.client_id = client.id
+WHERE (:auth_state IS NULL OR latest_auth.auth_state = :auth_state)
+AND   (:commit_hash IS NULL OR latest_commit.commit_hash = :commit_hash)
+"""
+
+def query_client_states(session: Session, report_time: datetime = None, auth_state: DbAuthState = None, latest_commit: bool = None) -> list[DbClientStateView]:
+    """ Query the database for the last-reported state of every client at the given timestamp,
+    optionally filtering on a given state """
+    report_timestamp = report_time or datetime.now()
+
+    commit_hash = session.scalars(select(DbGitCommit)
+        .where(DbGitCommit.commit_time <= report_timestamp)
+        .order_by(DbGitCommit.commit_time.desc())
+        .limit(1)).first().commit_hash if latest_commit else None
+
+    return session.query(DbClientStateView).from_statement(text(REPORT_SQL)).params({
+        'report_time': report_timestamp,
+        'auth_state': auth_state,
+        'commit_hash': commit_hash
+    }).all()
+ 
+

--- a/webapp/db/db.py
+++ b/webapp/db/db.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker, Session
 from .db_schema import Base, DbClient, DbClientAuthEvent, DbAuthState, DbClientCommitAccess, DbClientAuthChallenge, DbGitCommit
+from .client_state_report import query_client_states
 from os import environ
 from models import models
 from fastapi import HTTPException
@@ -92,27 +93,6 @@ def log_client_repo_access(client_name: str, git_hash: str):
         session.add(client_access)
         session.commit()
 
-def _get_current_status_for_client(client: DbClient) -> models.ClientAccessStatus:
-    latest_auth_state = sorted(client.auth_sessions, key = lambda s: s.expires, reverse=True)[0] \
-        if client.auth_sessions else None
-    latest_repo_access = sorted(client.repo_access, key = lambda s: s.access_time, reverse=True)[0] \
-        if client.repo_access else None
-    return models.ClientStatus(
-        client_name = client.name, 
-        auth_state = models.ClientAuthState.from_db(latest_auth_state), 
-        repo_access = models.ClientAccessStatus.from_db(latest_repo_access))
-
-def get_current_client_status(client_name: str) -> models.ClientAccessStatus:
-    """ Get the current auth token status and repo status of the given client """
-
-def get_current_client_statuses() -> list[models.ClientAccessStatus]:
-    """ Get the current auth token status and repo access times for each client """
-    with DbSession() as session:
-        clients : list[DbClient] = session.scalars(select(DbClient).where(DbClient.valid == True))
-        if not clients:
-            raise HTTPException(404, "No valid clients found")
-        return [_get_current_status_for_client(client) for client in clients]
-
 def log_commit_fetch(commit_hash: str, commit_time: datetime):
     """ Log that a new commit has been pulled from the upstream """
     with DbSession() as session:
@@ -122,3 +102,10 @@ def log_commit_fetch(commit_hash: str, commit_time: datetime):
         
         session.add(DbGitCommit(commit_hash, commit_time))
         session.commit()
+
+
+def get_client_status_report(report_time: datetime = None, auth_state: DbAuthState = None, latest_commit: bool = None) -> list[models.ClientAccessStatus]:
+    """ Get the current auth token status and repo access times for each client """
+    with DbSession() as session:
+        client_states = query_client_states(session, report_time, auth_state, latest_commit)
+        return [models.ClientStatus.from_db(s) for s in client_states]

--- a/webapp/db/db.py
+++ b/webapp/db/db.py
@@ -104,7 +104,7 @@ def log_commit_fetch(commit_hash: str, commit_time: datetime):
         session.commit()
 
 
-def get_client_status_report(report_time: datetime = None, auth_state: DbAuthState = None, latest_commit: bool = None) -> list[models.ClientAccessStatus]:
+def get_client_status_report(report_time: datetime = None, auth_state: models.AuthStateQuery = None, latest_commit: bool = None) -> list[models.ClientAccessStatus]:
     """ Get the current auth token status and repo access times for each client """
     with DbSession() as session:
         client_states = query_client_states(session, report_time, auth_state, latest_commit)

--- a/webapp/db/db_schema.py
+++ b/webapp/db/db_schema.py
@@ -69,6 +69,23 @@ class DbClientAuthChallenge(Base):
         self.id_secret = id_secret
         self.challenge_secret = challenge_secret
 
+
+class DbGitCommit(Base):
+    """ Table for tracking the Git Commits that have been the HEAD """
+
+    __tablename__ = "repo_commits"
+
+    commit_hash = Column(String, primary_key=True)
+
+    commit_time = Column(DateTime)
+
+    sync_time = Column(DateTime)
+
+    def __init__(self, commit_hash, commit_time):
+        self.commit_hash = commit_hash
+        self.commit_time = commit_time
+        self.sync_time = datetime.now()
+
 class DbClientCommitAccess(Base):
     """ Table for tracking the latest version of the git repo accessed by a client """
     __tablename__ = "client_commit_access"
@@ -76,7 +93,7 @@ class DbClientCommitAccess(Base):
     id = Column(String, primary_key=True, default = _gen_uuid)
     client_id: Mapped[String] = mapped_column(ForeignKey('client.id'))
     
-    commit_hash = Column(String)
+    commit_hash: Mapped[String] = mapped_column(ForeignKey('repo_commits.commit_hash'))
     access_time = Column(DateTime)
 
     def __init__(self, client_id, commit_hash):

--- a/webapp/db/db_schema.py
+++ b/webapp/db/db_schema.py
@@ -104,7 +104,7 @@ class DbClientCommitAccess(Base):
         self.access_time = access_time
 
 
-class DbClientLatestState(Base):
+class DbClientStateView(Base):
     __tablename__ = "__client_latest_state"
 
     id = Column(String, primary_key=True, default = _gen_uuid)

--- a/webapp/db/db_schema.py
+++ b/webapp/db/db_schema.py
@@ -23,6 +23,7 @@ class DbClient(Base):
     repo_access: Mapped[list["DbClientCommitAccess"]] = relationship(cascade="delete")
 
     def __init__(self, name):
+        self.id = _gen_uuid()
         self.name = name
         self.valid = True
 
@@ -38,7 +39,7 @@ class DbClientAuthEvent(Base):
     client_id: Mapped[String] = mapped_column(ForeignKey('client.id'))
     auth_state = Column(String, nullable=False)
 
-    initiated = Column(DateTime, default=datetime.now())
+    initiated = Column(DateTime, default=datetime.now(), index=True)
     expires   = Column(DateTime, default=datetime.now())
 
     challenge: Mapped["DbClientAuthChallenge"] = relationship(cascade="delete")
@@ -96,8 +97,25 @@ class DbClientCommitAccess(Base):
     commit_hash: Mapped[String] = mapped_column(ForeignKey('repo_commits.commit_hash'))
     access_time = Column(DateTime)
 
-    def __init__(self, client_id, commit_hash):
+    def __init__(self, client_id, commit_hash, access_time = None):
         self.id = _gen_uuid()
         self.client_id = client_id
         self.commit_hash = commit_hash
+        self.access_time = access_time
+
+
+class DbClientLatestState(Base):
+    __tablename__ = "__client_latest_state"
+
+    id = Column(String, primary_key=True, default = _gen_uuid)
+    name = Column(String, unique=True, nullable=False)
+
+    auth_state = Column(String, nullable=False)
+
+    initiated = Column(DateTime, default=datetime.now(), index=True)
+    expires   = Column(DateTime, default=datetime.now())
+
+    commit_hash = Column(String)
+    access_time = Column(DateTime)
+
 

--- a/webapp/db/db_schema.py
+++ b/webapp/db/db_schema.py
@@ -29,7 +29,7 @@ class DbClient(Base):
 
 class DbAuthState(str, Enum):
     PENDING = 'PENDING'
-    ACTIVE = 'ACTIVE'
+    SUCCESSFUL = 'SUCCESSFUL'
     FAILED = 'FAILED'
 
 class DbClientAuthEvent(Base):
@@ -51,7 +51,7 @@ class DbClientAuthEvent(Base):
         self.initiated = datetime.now()
 
     def activate(self, expires):
-        self.auth_state = DbAuthState.ACTIVE
+        self.auth_state = DbAuthState.SUCCESSFUL
         self.expires = expires
     
     def fail(self):

--- a/webapp/db/db_schema.py
+++ b/webapp/db/db_schema.py
@@ -105,7 +105,13 @@ class DbClientCommitAccess(Base):
 
 
 class DbClientStateView(Base):
-    __tablename__ = "__client_latest_state"
+    """
+    Db Model class for the non-manifested view that displays the latest state for each client
+    prior to a given timestamp (see client_state_report.py)
+    # TODO figure out a way to explicitly mark this as a view - SQLAlchemy currently creates
+    an empty table for it
+    """
+    __tablename__ = "__client_state_view"
 
     id = Column(String, primary_key=True, default = _gen_uuid)
     name = Column(String, unique=True, nullable=False)

--- a/webapp/models/models.py
+++ b/webapp/models/models.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import datetime
-from db.db_schema import DbClientCommitAccess, DbClientAuthEvent
+from db.db_schema import DbClientCommitAccess, DbClientAuthEvent, DbClientStateView
 
 
 
@@ -62,6 +62,19 @@ class ClientStatus(BaseModel):
     client_name: str
     auth_state: Optional[ClientAuthState]
     repo_access: Optional[ClientAccessStatus]
+
+    @classmethod
+    def from_db(cls, entity: DbClientStateView):
+        return ClientStatus(
+            client_name=entity.name,
+            auth_state=ClientAuthState(
+                state=entity.auth_state,
+                initiated=entity.initiated,
+                expires=entity.expires) if entity.auth_state else None,
+            repo_access=ClientAccessStatus(
+                access_time=entity.access_time,
+                commit_hash=entity.commit_hash) if entity.commit_hash else None)
+
 
 
 class SecretVersion(BaseModel):

--- a/webapp/models/models.py
+++ b/webapp/models/models.py
@@ -29,7 +29,7 @@ class RepoListing(BaseModel):
     commit_hash: str = Field(description="Hash of the latest commit for the repository")
 
 
-class ClientGitRepoStatus(BaseModel):
+class ClientAccessStatus(BaseModel):
     access_time: datetime
     commit_hash: str
 
@@ -38,13 +38,14 @@ class ClientGitRepoStatus(BaseModel):
         if entity is None:
             return None
         
-        return ClientGitRepoStatus(
+        return ClientAccessStatus(
             access_time=entity.access_time,
             commit_hash=entity.commit_hash
         )
 
 class ClientAuthState(BaseModel):
     state: str
+    initiated: Optional[datetime]
     expires: Optional[datetime]
 
     @classmethod
@@ -54,12 +55,13 @@ class ClientAuthState(BaseModel):
         
         return ClientAuthState(
             state=entity.auth_state,
+            initiated=entity.initiated,
             expires=entity.expires)
 
 class ClientStatus(BaseModel):
     client_name: str
     auth_state: Optional[ClientAuthState]
-    repo_access: Optional[ClientGitRepoStatus]
+    repo_access: Optional[ClientAccessStatus]
 
 
 class SecretVersion(BaseModel):

--- a/webapp/models/models.py
+++ b/webapp/models/models.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import datetime
-from db.db_schema import DbClientRepoAccess, DbClientAuthSession
+from db.db_schema import DbClientCommitAccess, DbClientAuthEvent
 
 
 
@@ -34,7 +34,7 @@ class ClientGitRepoStatus(BaseModel):
     commit_hash: str
 
     @classmethod
-    def from_db(cls, entity: DbClientRepoAccess):
+    def from_db(cls, entity: DbClientCommitAccess):
         if entity is None:
             return None
         
@@ -48,7 +48,7 @@ class ClientAuthState(BaseModel):
     expires: Optional[datetime]
 
     @classmethod
-    def from_db(cls, entity: DbClientAuthSession):
+    def from_db(cls, entity: DbClientAuthEvent):
         if entity is None:
             return None
         

--- a/webapp/models/models.py
+++ b/webapp/models/models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+from enum import Enum
 from typing import Optional
 from datetime import datetime
 from db.db_schema import DbClientCommitAccess, DbClientAuthEvent, DbClientStateView
@@ -82,3 +83,17 @@ class SecretVersion(BaseModel):
     secret: str
     iat: datetime
     exp: datetime
+
+
+class AuthStateQuery(Enum):
+    """ Query parameter enum for  """
+    # Auth states that are recorded in the DB
+    PENDING = 'PENDING'
+    SUCCESSFUL = 'SUCCESSFUL'
+    FAILED = 'FAILED'
+    # A successful auth entry whose expiration has passed
+    EXPIRED = 'EXPIRED'
+    # Do not filter on auth state in the query
+    ANY = 'ANY'
+    # Has not yet attempted to authenticate
+    NONE = 'NONE'

--- a/webapp/test/benchmark_db.py
+++ b/webapp/test/benchmark_db.py
@@ -31,7 +31,7 @@ def _add_git_commits(session: Session, client: DbClient):
 def _add_access_logs(session: Session, client: DbClient):
     for i in range(AUTH_COUNT):
         auth_event = DbClientAuthEvent(client.id)
-        auth_event.auth_state = DbAuthState.ACTIVE
+        auth_event.auth_state = DbAuthState.SUCCESSFUL
         auth_event.initiated = START_TIME - timedelta(hours=2*i)
         auth_event.expires = auth_event.initiated + timedelta(hours=2)
         session.add(auth_event)

--- a/webapp/test/benchmark_db.py
+++ b/webapp/test/benchmark_db.py
@@ -1,0 +1,120 @@
+from db.db import DbSession
+from sqlalchemy import select, text
+from db.db_schema import DbClient, DbGitCommit, DbClientCommitAccess, DbClientAuthEvent, DbAuthState, DbClientLatestState
+from sqlalchemy.orm import Session
+from datetime import datetime, timedelta
+from functools import wraps
+
+CLIENT_COUNT = 100
+COMMIT_COUNT = 75
+AUTH_COUNT = 500
+
+START_TIME = datetime.now()
+
+def with_time_logging(func):
+    @wraps(func)
+    def _log_time(*args,**kwargs):
+        start_time = datetime.now()
+        print(f"Starting {func} at {start_time}")
+        try:
+            func(*args, **kwargs)
+        finally:
+            print(f"Elapsed: {datetime.now() - start_time }")
+    return _log_time
+
+
+def _add_git_commits(session: Session, client: DbClient):
+    for i in range(COMMIT_COUNT):
+        session.add(DbClientCommitAccess(client.id, f"{i}", START_TIME - timedelta(days = i)))
+
+
+def _add_access_logs(session: Session, client: DbClient):
+    for i in range(AUTH_COUNT):
+        auth_event = DbClientAuthEvent(client.id)
+        auth_event.auth_state = DbAuthState.ACTIVE
+        auth_event.initiated = START_TIME - timedelta(hours=2*i)
+        auth_event.expires = auth_event.initiated + timedelta(hours=2)
+        session.add(auth_event)
+
+@with_time_logging
+def populate_db():
+    with DbSession() as session:
+        # Add Git Commits
+        for i in range(COMMIT_COUNT):
+            session.add(DbGitCommit(f"{i}", START_TIME - timedelta(days = i)))
+
+        for i in range(CLIENT_COUNT):
+            client = DbClient(f"{i}")
+            session.add(client)
+            _add_git_commits(session, client)
+            _add_access_logs(session, client)
+        session.commit()
+
+def print_db_stats():
+    with DbSession() as session:
+        print(f"Client Count: {session.query(DbClient.id).count()}")
+        print(f"Commit Access Count: {session.query(DbClientCommitAccess.id).count()}")
+        print(f"Auth Event Count: {session.query(DbClientAuthEvent.id).count()}")
+
+@with_time_logging
+def find_latest_auth_iter():
+    with DbSession() as session:
+        auth_sessions = []
+        client_ids = session.scalars(select(DbClient.id))
+        for id in client_ids:
+            auth_sessions.append(session.scalar(select(DbClientAuthEvent)
+                .where(DbClientAuthEvent.client_id == id)
+                .order_by(DbClientAuthEvent.initiated.desc())
+                .limit(1)))
+        print(len(auth_sessions))
+
+@with_time_logging
+def find_latest_auth_window():
+    with DbSession() as session:
+        auth_sessions = session.query(DbClientAuthEvent).from_statement(text("""
+            WITH ordered_auth AS (
+                SELECT *, row_number() over (partition by client_id order by initiated desc) as row_num
+                FROM client_auth_sessions
+            )
+            SELECT * FROM ordered_auth where row_num = 1"""
+        )).all()
+        print(len(auth_sessions))
+
+@with_time_logging
+def find_latest_auth_inner_query():
+    with DbSession() as session:
+        auth_sessions = session.query(DbClientLatestState).from_statement(text("""
+        WITH latest_auth AS (
+            SELECT client_auth_sessions.* FROM client
+            LEFT JOIN client_auth_sessions ON client.id = client_auth_sessions.client_id
+            WHERE client_auth_sessions.id = (
+                SELECT id FROM client_auth_sessions
+                WHERE client_auth_sessions.client_id = client.id
+                ORDER BY initiated DESC
+                LIMIT 1
+            )
+        ), latest_commit AS (
+            SELECT client_commit_access.* FROM client
+            LEFT JOIN client_commit_access ON client.id = client_commit_access.client_id
+            WHERE client_commit_access.id = (
+                SELECT id FROM client_commit_access
+                WHERE client_commit_access.client_id = client.id
+                ORDER BY access_time DESC
+                LIMIT 1
+            )
+        )
+        SELECT 
+            client.id, client.name,
+            latest_auth.auth_state, latest_auth.initiated, latest_auth.expires,
+            latest_commit.commit_hash, latest_commit.access_time
+        FROM client
+        LEFT JOIN latest_auth ON latest_auth.client_id = client.id
+        LEFT JOIN latest_commit ON latest_commit.client_id = client.id
+        """)).all()
+        print(len(auth_sessions))
+if __name__ == '__main__':
+    populate_db()
+    print_db_stats()
+    find_latest_auth_iter()
+    find_latest_auth_window()
+    find_latest_auth_inner_query()

--- a/webapp/test/benchmark_db.py
+++ b/webapp/test/benchmark_db.py
@@ -1,6 +1,6 @@
 from db.db import DbSession
 from sqlalchemy import select, text
-from db.db_schema import DbClient, DbGitCommit, DbClientCommitAccess, DbClientAuthEvent, DbAuthState, DbClientLatestState
+from db.db_schema import DbClient, DbGitCommit, DbClientCommitAccess, DbClientAuthEvent, DbAuthState, DbClientStateView
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta
 from functools import wraps
@@ -83,7 +83,7 @@ def find_latest_auth_window():
 @with_time_logging
 def find_latest_auth_inner_query():
     with DbSession() as session:
-        auth_sessions = session.query(DbClientLatestState).from_statement(text("""
+        auth_sessions = session.query(DbClientStateView).from_statement(text("""
         WITH latest_auth AS (
             SELECT client_auth_sessions.* FROM client
             LEFT JOIN client_auth_sessions ON client.id = client_auth_sessions.client_id


### PR DESCRIPTION
Pull request that updates the auth exchange tracking database to conform to the Glidein Manager [Access Tracking Design Doc](https://docs.google.com/document/d/1VnFulJiwkNaItRuP_c0BY8pvUlN3YxKSikdvihPQ25A/edit?usp=sharing). The set of changes from the previous implementation are roughly as follows:
- Create a separate, temporary table for auth exchange challenge secrets rather than storing them in a nullable column in the authentications table
- Add a metadata table for HEAD commits that have been downloaded by the GM, rather than just storing commit hashes in the CE commit access table
- Add a view that displays the latest auth session and commit access for each CE for usage in report generation